### PR TITLE
Update lodash for security audit.  Bump to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "country-query",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
+      "dev": true
+    },
+    "chai": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-2.3.0.tgz",
+      "integrity": "sha1-ii9qNHSNqAEJD9cyh7Kqc5pOkJo=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.0",
+        "deep-eql": "0.1.3"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash-deep": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lodash-deep/-/lodash-deep-1.6.0.tgz",
+      "integrity": "sha1-p85nJ1lHK5HRKxk8adiiSgLYQo0=",
+      "requires": {
+        "lodash": ">=2.4.1"
+      }
+    },
+    "type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+      "dev": true
+    },
+    "world-countries": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/world-countries/-/world-countries-1.8.1.tgz",
+      "integrity": "sha1-FLp9c11CLWPecN62417F5JNBsgk="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "country-query",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A javascript query API for world-countries data",
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
     "test": "test"
   },
   "dependencies": {
-    "lodash": "^3.5.0",
+    "lodash": "^4.17.15",
     "lodash-deep": "^1.6.0",
     "world-countries": "^1.7.8"
   },


### PR DESCRIPTION
Hey,

Wanted to suggest bumping version and incorporating the latest version of lodash that triggers an `npm audit` warning.

Thanks!

--Fiid,