### PR TITLE
Update to version 4.0.0 of world-countries data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.0] - 2021-03-11
+### Added
+- Added `findByIdd()` function (this replaces `findByCallingCode()`).
+- Added 'currencies', 'idd' and 'demonyms' as possible values of the `by` param to `find()`.
+
+### Changed
+- Updated to version 4.0.0 of world-countries data.
+- Structure of the country objects returned by `find()` has been updated due to the above.
+
+### Removed
+- Removed `findByCallingCode()` as the `callingCode` field no longer exists in the world-countries data.
+- Removed 'currency', 'callingCode' and 'demonym' as possible values of the `by` param to `find()`.
+
 ## [1.1.2] - 2020-08-30
 ### Changed
 - Upgraded to latest version of lodash.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,13 @@ var germany = CountryQuery.find('demonym', 'German')
         "cioc": "AUT",
         "independent": true,
         "status": "officially-assigned",
-        "currency": ["EUR"],
-        "callingCode": ["43"],
+        "currencies": {
+            "EUR": { "name": "Euro", "symbol": "\u20ac" }
+        },
+        "idd": {
+            "root": "+4",
+            "suffixes": ["3"]
+        },
         "capital": ["Vienna"],
         "altSpellings": ["AT", "Osterreich", "Oesterreich"],
         "region": "Europe",
@@ -71,16 +76,24 @@ var germany = CountryQuery.find('demonym', 'German')
             // ...snip...
         },
         "latlng": [47.33333333, 13.33333333],
-        "demonym": "Austrian",
         "landlocked": true,
         "borders": ["CZE", "DEU", "HUN", "ITA", "LIE", "SVK", "SVN", "CHE"],
         "area": 83871,
-        "flag": "🇦🇹"
+        "flag": "\ud83c\udde6\ud83c\uddf9",
+        "demonyms": {
+            "eng": {
+                "f": "Austrian",
+                "m": "Austrian"
+            },
+            "fra": {
+                "f": "Autrichienne",
+                "m": "Autrichien"
+            }
+        }
     }
-
  */
 
-var euroCountries = CountryQuery.find('currency', 'EUR')
+var euroCountries = CountryQuery.find('currencies', 'EUR')
 
 // euroCountries will be an array of country objects
 ```
@@ -88,8 +101,8 @@ var euroCountries = CountryQuery.find('currency', 'EUR')
 Acceptable values for `by` are:
 
 - `tld`
-- `currency`
-- `callingCode`
+- `currencies`
+- `idd`
 - `altSpellings`
 - `latlng`
 - `borders`
@@ -105,7 +118,7 @@ Acceptable values for `by` are:
 - `cioc`
 - `region`
 - `subregion`
-- `demonym`
+- `demonyms`
 - `landlocked`
 - `area`
 
@@ -127,7 +140,7 @@ Find country by countries that it borders
 
 Return value is the same as [find](#findby-value).
 
-### findByCallingCode(callingCode)
+### findByIdd(idd)
 
 Find country by telephone calling code.
 
@@ -171,7 +184,7 @@ Return value is the same as [find](#findby-value).
 
 ### findByDemonym(demonym)
 
-Find country by the demonym used for its citizens.
+Find country by one of the demonyms used for its citizens.
 
 Return value is the same as [find](#findby-value).
 

--- a/lib/country-query.js
+++ b/lib/country-query.js
@@ -2,18 +2,20 @@ var _ = require('lodash')
 var cs = require('world-countries')
 
 var PROP_TYPE_ARRAY = 'array',
+  PROP_TYPE_CURRENCY_MAP = 'currency',
   PROP_TYPE_MAP = 'map',
   PROP_TYPE_DEEP_STRING = 'deep_string',
+  PROP_TYPE_IDD = 'idd',
   PROP_TYPE_LANG_KEYED_NAME = 'lang_keyed_name',
   PROP_TYPE_STRING = 'string'
 
 var propTypes = {
   tld: PROP_TYPE_ARRAY,
-  currency: PROP_TYPE_ARRAY,
-  callingCode: PROP_TYPE_ARRAY,
+  currencies: PROP_TYPE_CURRENCY_MAP,
   altSpellings: PROP_TYPE_ARRAY,
   latlng: PROP_TYPE_ARRAY,
   borders: PROP_TYPE_ARRAY,
+  idd: PROP_TYPE_IDD,
   'name.common': PROP_TYPE_DEEP_STRING,
   'name.official': PROP_TYPE_DEEP_STRING,
   'name.native': PROP_TYPE_LANG_KEYED_NAME,
@@ -26,7 +28,7 @@ var propTypes = {
   capital: PROP_TYPE_ARRAY,
   region: PROP_TYPE_STRING,
   subregion: PROP_TYPE_STRING,
-  demonym: PROP_TYPE_STRING,
+  demonyms: PROP_TYPE_LANG_KEYED_NAME,
   landlocked: PROP_TYPE_STRING,
   area: PROP_TYPE_STRING,
 }
@@ -45,8 +47,14 @@ var CountryQuery = {
       case PROP_TYPE_ARRAY:
         return findByArrayProp(by, value)
 
+      case PROP_TYPE_CURRENCY_MAP:
+        return findByCurrencyInternal(value)
+
       case PROP_TYPE_DEEP_STRING:
         return findByDeepStringProp(by, value)
+
+      case PROP_TYPE_IDD:
+        return findByIddInternal(value)
 
       case PROP_TYPE_LANG_KEYED_NAME:
         return findByLangKeyedName(by, value)
@@ -85,15 +93,6 @@ var CountryQuery = {
    */
   findByBorders: function (borders) {
     return this.find('borders', borders)
-  },
-
-  /**
-   * Find country by telephone calling code
-   * @param  {string} callingCode
-   * @return {mixed} See #find()
-   */
-  findByCallingCode: function (callingCode) {
-    return this.find('callingCode', callingCode)
   },
 
   /**
@@ -147,16 +146,25 @@ var CountryQuery = {
    * @return {mixed} See #find()
    */
   findByCurrency: function (currency) {
-    return this.find('currency', currency)
+    return this.find('currencies', currency)
   },
 
   /**
-   * Find country by the demonym used for its citizens.
+   * Find country by one of the demonyms used for its citizens.
    * @param  {string} demonym
    * @return {mixed} See #find()
    */
   findByDemonym: function (demonym) {
-    return this.find('demonym', demonym)
+    return this.find('demonyms', demonym)
+  },
+
+  /**
+   * Find country by telephone IDD
+   * @param  {string} idd
+   * @return {mixed} See #find()
+   */
+  findByIdd: function (idd) {
+    return this.find('idd', idd)
   },
 
   /**
@@ -259,6 +267,28 @@ function findByArrayProp(prop, value) {
 }
 
 /**
+ * Searches the 'currencies' property.
+ * @param {mixed} value Value to find
+ * @returns {mixed}     See filteredToResult
+ */
+function findByCurrencyInternal(value) {
+  var searchVal = lowerCaseIfNeeded(value)
+  var filtered = _.filter(cs, function (c) {
+    if (c.currencies[upperCaseIfNeeded(value)]) {
+      return true
+    }
+
+    return _(c.currencies)
+      .values()
+      .some(function (v) {
+        return lowerCaseIfNeeded(v) === searchVal
+      })
+  })
+
+  return filteredToResult(filtered)
+}
+
+/**
  * Searches properties that contain strings but are nested inside another
  * property (e.g. 'name.common').
  * @param  {string} propPath A property path
@@ -275,11 +305,38 @@ function findByDeepStringProp(propPath, value) {
 }
 
 /**
- * Searches properties that contain a list of names keyed by language code:
+ * Searches the 'idd' property.
+ * @param {mixed} value Value to find
+ * @returns{mixed}      See filteredToResult
+ */
+function findByIddInternal(value) {
+  var searchVal = typeof value !== 'string' ? value.toString() : value
+  if (!searchVal.startsWith('+')) {
+    searchVal = '+' + searchVal
+  }
+  // "idd": { "root": "+2", "suffixes": [ "90", "47" ] }
+  var filtered = _.filter(cs, function (c) {
+    for (var i = 0; i < c.idd.suffixes.length; i++) {
+      if ([c.idd.root, c.idd.suffixes[i]].join('') === searchVal) {
+        return true
+      }
+    }
+    return false
+  })
+
+  return filteredToResult(filtered)
+}
+
+/**
+ * Searches properties that contain a list of names/demonyms keyed by language code:
  *
  *   {
- *     "nld": { "official": "Aruba", "common": "Aruba"},
- *     "pap": {"official": "Aruba", "common": "Aruba"}
+ *     "nld": { "official": "Aruba", "common": "Aruba" },
+ *     "pap": { "official": "Aruba", "common": "Aruba" }
+ *   }
+ *   {
+ *     "eng": { "f": "Irish", "m": "Irish" },
+ *     "fra": { "f": "Irlandaise", "m": "Irlandais" }
  *   }
  *
  * @param  {string} propPath A property path
@@ -298,7 +355,9 @@ function findByLangKeyedName(propPath, value) {
     for (var langKey in nameObj) {
       if (
         lowerCaseIfNeeded(nameObj[langKey].official) === searchVal ||
-        lowerCaseIfNeeded(nameObj[langKey].common) === searchVal
+        lowerCaseIfNeeded(nameObj[langKey].common) === searchVal ||
+        lowerCaseIfNeeded(nameObj[langKey].f) === searchVal ||
+        lowerCaseIfNeeded(nameObj[langKey].m) === searchVal
       ) {
         return true
       }
@@ -352,6 +411,15 @@ function findByStringProp(prop, value) {
  */
 function lowerCaseIfNeeded(value) {
   return typeof value === 'string' ? value.toLowerCase() : value
+}
+
+/**
+ * Converts a value to upper case if necessary (i.e. if it is a string).
+ * @param  {mixed} value Value to (possible) upper-case
+ * @return {mixed}       Upper-cased string, if `value` is a string, or unchanged `value`, otherwise.
+ */
+function upperCaseIfNeeded(value) {
+  return typeof value === 'string' ? value.toUpperCase() : value
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "country-query",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "A javascript query API for world-countries data",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.20",
-    "world-countries": "^2.1.0"
+    "world-countries": "^4.0.0"
   },
   "devDependencies": {
     "chai": "4.2.0",

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ describe('CountryQuery', function () {
         'cca3',
         'ABW'
       )
-      expect(CountryQuery.find('demonym', 'Aruban')).to.have.property(
+      expect(CountryQuery.find('demonyms', 'Aruban')).to.have.property(
         'cca3',
         'ABW'
       )
@@ -33,7 +33,7 @@ describe('CountryQuery', function () {
         'cca3',
         'ABW'
       )
-      expect(CountryQuery.find('currency', 'AWG')).to.have.property(
+      expect(CountryQuery.find('currencies', 'AWG')).to.have.property(
         'cca3',
         'ABW'
       )
@@ -45,7 +45,7 @@ describe('CountryQuery', function () {
     })
 
     it('should return an array when finding by non-uniquely identifiable array properties', function () {
-      var gbpCountries = CountryQuery.find('currency', 'gbp')
+      var gbpCountries = CountryQuery.find('currencies', 'gbp')
       var uk = CountryQuery.find('cca2', 'GB')
 
       expect(gbpCountries).to.be.an('array').and.have.length(6)
@@ -101,7 +101,7 @@ describe('CountryQuery', function () {
         { field: 'ccn3', value: '000' },
         { field: 'cca3', value: 'XXX' },
         { field: 'capital', value: 'XXXXX' },
-        { field: 'demonym', value: 'XXXXXXX' },
+        { field: 'demonyms', value: 'XXXXXXX' },
       ]
       nullTests.forEach(function (test) {
         expect(CountryQuery.find(test.field, test.value)).to.be.null
@@ -158,9 +158,9 @@ describe('CountryQuery', function () {
         },
         { field: 'area', value: 6, findFunc: 'findByArea', expectCca3: 'GIB' },
         {
-          field: 'callingCode',
+          field: 'idd',
           value: '355',
-          findFunc: 'findByCallingCode',
+          findFunc: 'findByIdd',
           expectCca3: 'ALB',
         },
         {
@@ -194,7 +194,7 @@ describe('CountryQuery', function () {
           expectCca3: 'RWA',
         },
         {
-          field: 'demonym',
+          field: 'demonyms',
           value: 'Qatari',
           findFunc: 'findByDemonym',
           expectCca3: 'QAT',
@@ -241,6 +241,12 @@ describe('CountryQuery', function () {
           findFunc: 'findByTranslation',
           expectCca3: 'AND',
         },
+        {
+          field: 'currencies',
+          value: 'VES',
+          findFunc: 'findByCurrency',
+          expectCca3: 'VEN',
+        },
       ]
 
       findSingleTests.forEach(function (test) {
@@ -268,7 +274,7 @@ describe('CountryQuery', function () {
           expectLength: 6,
         },
         {
-          field: 'currency',
+          field: 'currencies',
           value: 'GBP',
           findFunc: 'findByCurrency',
           expectLength: 6,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1287,10 +1287,10 @@ workerpool@6.0.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.0.tgz#85aad67fa1a2c8ef9386a1b43539900f61d03d58"
   integrity sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==
 
-world-countries@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/world-countries/-/world-countries-2.1.0.tgz#935a3bb5839a88bc1c7d05b8645341db4edd48d4"
-  integrity sha512-g8DRgoH7UJiF5L0xjj+RP/GFH4fOVlD3J5CxkJ+PZYH1PNl0i5JrstBOX53Ub8ObTZ6lCx0V7nIA8BuCvxMoSg==
+world-countries@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/world-countries/-/world-countries-4.0.0.tgz#a14757e2240d8c16249e3c6e6cdcd61d119a042d"
+  integrity sha512-LsFFYmggquj0U+i7VUaJOZYz5F4QNu+oceGw8odnyVHMT2LxYSdVncqdouOEnq1esr7yCakp9+3BZTztuSw1Pg==
 
 wrap-ansi@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
This upgrade introduces some breaking changes:

#### Added
- Added `findByIdd()` function (this replaces `findByCallingCode()`).
- Added 'currencies', 'idd' and 'demonyms' as possible values of the `by` param to `find()`.

#### Changed
- Updated to version 4.0.0 of world-countries data.
- Structure of the country objects returned by `find()` has been updated due to the above.

#### Removed
- Removed `findByCallingCode()` as the `callingCode` field no longer exists in the world-countries data.
- Removed 'currency', 'callingCode' and 'demonym' as possible values of the `by` param to `find()`.